### PR TITLE
feat: add functionality to discover existing dataset from disk

### DIFF
--- a/src/open_icu/storage/project.py
+++ b/src/open_icu/storage/project.py
@@ -60,6 +60,8 @@ class OpenICUProject(FileStorage):
         self._datasets = {}
         self._workspace = {}
 
+        self._discover_datasets()
+
     def __enter__(self) -> "OpenICUProject":
         """Enter context manager.
 
@@ -164,3 +166,28 @@ class OpenICUProject(FileStorage):
         )
         self._datasets[name] = dataset
         return dataset
+
+    def _discover_datasets(self) -> None:
+        """Register MEDS datasets already present on disk under ``datasets/``.
+
+        A dataset is otherwise only registered when its producing step runs in
+        the current session (via :meth:`add_dataset`). Rediscovering existing
+        datasets when the project is opened lets a later step resolve the output
+        of an earlier step that ran in a previous session — e.g. running the
+        concept step against a project whose extraction output is already on
+        disk — without having to re-run it. Existing contents are preserved
+        (``overwrite=False``).
+        """
+        if not self.datasets_path.is_dir():
+            return
+
+        for dataset_path in sorted(self.datasets_path.iterdir()):
+            if not dataset_path.is_dir():
+                continue
+
+            logger.info(
+                "Discovered existing dataset '%s' at %s",
+                dataset_path.name,
+                dataset_path,
+            )
+            self.add_dataset(dataset_path.name, overwrite=False)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -73,6 +73,31 @@ class TestOpenICUProject:
         assert project.workspace == {"extraction": workspace}
         assert project.datasets == {"extraction": dataset}
 
+    def test_rediscovers_existing_datasets_on_reopen(self, tmp_path: Path) -> None:
+        """Re-opening a project registers datasets already on disk, so a later
+        step can resolve an earlier step's output without re-running it."""
+        project_path = tmp_path / "project"
+
+        # First session: produce an extraction dataset with one data file.
+        first = OpenICUProject(project_path)
+        extraction = first.add_dataset("extraction")
+        table_dir = extraction.data_path / "aumc" / "1.5.0" / "measurement"
+        table_dir.mkdir(parents=True)
+        pl.DataFrame({"code": ["aumc//measurement//1"]}).write_parquet(table_dir / "MEASUREMENT.parquet")
+
+        # Second session: a fresh project instance at the same path.
+        reopened = OpenICUProject(project_path)
+
+        assert "extraction" in reopened.datasets
+        rediscovered = reopened.datasets["extraction"]
+        assert rediscovered.data_path == extraction.data_path
+        # contents are preserved (overwrite=False), not wiped
+        assert (table_dir / "MEASUREMENT.parquet").exists()
+
+    def test_fresh_project_discovers_no_datasets(self, tmp_path: Path) -> None:
+        project = OpenICUProject(tmp_path / "project")
+        assert project.datasets == {}
+
 
 class TestMEDSDataset:
     def test_write_metadata(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Allow `OpenICUProject`s to initialise from disk. 

## Related Issue(s)

#563 

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] Test or tooling improvement

## Checklist

- [x] Code is tested and builds correctly
- [ ] Docs updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)
