### PR TITLE
fix: correct `eicu` admission dates

### DIFF
--- a/configs/datasets/eicu-crd/2.0/tables/admissiondx.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/admissiondx.yml
@@ -37,7 +37,7 @@ join:
       - patientunitstayid
 
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 
 post_join_callbacks:

--- a/configs/datasets/eicu-crd/2.0/tables/diagnosis.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/diagnosis.yml
@@ -35,7 +35,7 @@ join:
       - patientunitstayid
 
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
     post_join_callbacks:
       - add_offset(admission_timestamp, diagnosisoffset, output=event_timestamp)

--- a/configs/datasets/eicu-crd/2.0/tables/infusiondrug.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/infusiondrug.yml
@@ -43,7 +43,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/intakeoutput.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/intakeoutput.yml
@@ -50,7 +50,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/lab.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/lab.yml
@@ -42,7 +42,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/medication.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/medication.yml
@@ -46,7 +46,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/nursecharting.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/nursecharting.yml
@@ -39,7 +39,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/patient.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/patient.yml
@@ -62,7 +62,11 @@ columns:
     type: int64
 
 post_join_callbacks:
-  - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+  # eICU offsets are relative to ICU admission. hospitalAdmitOffset is normally
+  # negative, so subtracting it moves forward from hospital to ICU admission.
+  - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, output=hospital_admission_timestamp)
+  - add_offset(hospital_admission_timestamp, hospitaladmitoffset * -1, output=admission_timestamp)
+  - add_offset(admission_timestamp, hospitaldischargeoffset, output=hospital_discharge_timestamp)
   - add_offset(admission_timestamp, unitdischargeoffset, output=discharge_timestamp)
   - add_offset(admission_timestamp, cast(replace(age == "> 89", "90", age), "int16") * 365.25, offset_unit="days", output=birth_timestamp)
   - replace((gender == "") or (gender == None), "Unknown", gender, output=gender_1)
@@ -78,6 +82,18 @@ events:
       time: col(birth_timestamp)
       code:
         - col(gender_1)
+
+  - name: HOSPITAL_ADMISSION
+    columns:
+      time: col(hospital_admission_timestamp)
+      code:
+        - col(hospitaladmitsource)
+      extension:
+        available_time: col(hospital_admission_timestamp)
+    filters:
+      - drop_na(time)
+      - first_distinct(subject_id, time)
+
   - name: ICU_ADMISSION
     columns:
       time: col(admission_timestamp)
@@ -126,6 +142,18 @@ events:
         - col(unittype)
       extension:
         available_time: col(discharge_timestamp)
+
+  - name: HOSPITAL_DISCHARGE
+    columns:
+      time: col(hospital_discharge_timestamp)
+      code:
+        - col(hospitaldischargelocation)
+      text_value: col(hospitaldischargestatus)
+      extension:
+        available_time: col(hospital_discharge_timestamp)
+    filters:
+      - drop_na(time)
+      - first_distinct(subject_id, time)
 
   - name: SUBJECT_WEIGHT
     columns:

--- a/configs/datasets/eicu-crd/2.0/tables/respiratorycare.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/respiratorycare.yml
@@ -47,7 +47,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/respiratorycharting.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/respiratorycharting.yml
@@ -40,7 +40,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/treatment.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/treatment.yml
@@ -31,7 +31,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)

--- a/configs/datasets/eicu-crd/2.0/tables/vitalaperiodic.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/vitalaperiodic.yml
@@ -56,7 +56,7 @@ join:
       - patientunitstayid
 
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
     post_join_callbacks:
       - add_offset(admission_timestamp, observationoffset, output=event_timestamp)

--- a/configs/datasets/eicu-crd/2.0/tables/vitalperiodic.yml
+++ b/configs/datasets/eicu-crd/2.0/tables/vitalperiodic.yml
@@ -69,7 +69,7 @@ join:
     both_on:
       - patientunitstayid
     callbacks:
-      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset, "minutes", output=admission_timestamp)
+      - to_datetime(hospitaldischargeyear, 1, 1, hospitaladmittime24, hospitaladmitoffset * -1, "minutes", output=admission_timestamp)
 
 event_defaults:
   subject_id: col(patienthealthsystemstayid)


### PR DESCRIPTION
## Summary

The offset in `eicu` configs was incorrectly applied. The configs were also missing hospital admission events. 

## Related Issue(s)

#609 

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] Test or tooling improvement

## Checklist

- [x Code is tested and builds correctly
- [ ] Docs updated (if applicable)
- [x PR title follows [Conventional Commits](https://www.conventionalcommits.org)
