### PR TITLE
fix(eicu): make insulin mapping pattern case-insensitive

### DIFF
--- a/configs/datasets/eicu-crd/2.0/mappings/insulin.yml
+++ b/configs/datasets/eicu-crd/2.0/mappings/insulin.yml
@@ -3,7 +3,7 @@ mappings:
   - pattern:
       table: infusiondrug
       event: INFUSION
-      code: (^insulin (250.+)?\(((ml|units)/hr)?\)$)
+      code: (?i)(^insulin (250.+)?\(((ml|units)/hr)?\)$)
     columns:
       numeric_value: col(numeric_value)
       text_value: col(text_value)


### PR DESCRIPTION
The eicu-crd insulin concept mapping matched codes anchored on lowercase "insulin", but extracted infusiondrug codes are Title Case (e.g. "INFUSION//Insulin (ml/hr)"), so the pattern never matched and the concept was always empty.

Add the (?i) case-insensitive flag, matching the same fix already applied to norepinephrine_rate and other drug-rate concepts in #681.

Verified against the eICU demo dataset: insulin went from 0 to 2,220 rows, bringing all 90 eicu-crd concepts to populated status.

## Summary

<!-- Describe the purpose of this PR in 1–2 sentences. -->

## Related Issue(s)

<!-- Link to any relevant issues. Use `Fixes #XX` or `Closes #XX` to auto-close. -->

## Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] Test or tooling improvement

## Checklist

- [ ] Code is tested and builds correctly
- [ ] Docs updated (if applicable)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org)

## Notes for Reviewer

<!-- Optional: highlight anything you'd like reviewers to pay extra attention to, or add context for tricky parts. -->
