### PR TITLE
feat(sharding): add configurable semantic event ordering

### DIFF
--- a/src/open_icu/config/default_event_order.yml
+++ b/src/open_icu/config/default_event_order.yml
@@ -1,0 +1,55 @@
+default_order: 30
+unassigned: warn
+
+groups:
+  hospital_admission:
+    order: 10
+    concepts:
+      - hospital_admission
+
+  icu_admission:
+    order: 11
+    concepts:
+      - icu_admission
+
+  demographics:
+    order: 20
+    concepts:
+      - patient_admission_type
+      - patient_age
+      - patient_height
+      - patient_sex
+      - patient_weight
+
+  derived_first_level:
+    order: 40
+    concepts:
+      - gcs_total
+      - aki_creatinine
+      - aki_urine_output
+
+  derived_components:
+    order: 50
+    concepts:
+      - aki
+      - sofa_cardiovascular
+      - sofa_cns
+      - sofa_coagulation
+      - sofa_liver
+      - sofa_renal
+      - sofa_respiratory
+
+  derived_aggregates:
+    order: 60
+    concepts:
+      - sofa
+
+  icu_discharge:
+    order: 90
+    concepts:
+      - icu_discharge
+
+  hospital_discharge:
+    order: 91
+    concepts:
+      - hospital_discharge

--- a/src/open_icu/config/event_order.py
+++ b/src/open_icu/config/event_order.py
@@ -1,0 +1,66 @@
+"""Global event-order configuration."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class EventOrderGroup(BaseModel):
+    """A group of concepts sharing the same event-order priority."""
+
+    order: int = Field(
+        ...,
+        description="Sort priority for concepts in this group. Lower values come first.",
+    )
+    concepts: list[str] = Field(
+        default_factory=list,
+        description="Concept names assigned to this event-order group.",
+    )
+
+
+class EventOrderConfig(BaseModel):
+    """Global configuration defining semantic ordering of simultaneous events."""
+
+    default_order: int = Field(
+        default=50,
+        description="Order used for concepts that are not assigned to any group.",
+    )
+    unassigned: Literal["ignore", "warn", "error"] = Field(
+        default="warn",
+        description="How to handle concepts that use the default event order.",
+    )
+    groups: dict[str, EventOrderGroup] = Field(
+        default_factory=dict,
+        description="Named semantic event-order groups.",
+    )
+
+    @model_validator(mode="after")
+    def validate_unique_concepts(self) -> "EventOrderConfig":
+        """Ensure each concept is assigned to at most one group."""
+        seen: dict[str, str] = {}
+
+        for group_name, group in self.groups.items():
+            for concept in group.concepts:
+                if "//" in concept:
+                    raise ValueError(
+                        f"Event-order concept '{concept}' must be a concept name, "
+                        "not a full code."
+                    )
+
+                if concept in seen:
+                    raise ValueError(
+                        f"Concept '{concept}' is assigned to multiple event-order "
+                        f"groups: '{seen[concept]}' and '{group_name}'."
+                    )
+
+                seen[concept] = group_name
+
+        return self
+
+    def concept_orders(self) -> dict[str, int]:
+        """Return a mapping from concept name to semantic sort order."""
+        return {
+            concept: group.order
+            for group in self.groups.values()
+            for concept in group.concepts
+        }

--- a/src/open_icu/config/event_order.py
+++ b/src/open_icu/config/event_order.py
@@ -1,8 +1,13 @@
 """Global event-order configuration."""
 
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Self
 
+import yaml
 from pydantic import BaseModel, Field, model_validator
+
+
+DEFAULT_EVENT_ORDER_CONFIG = Path(__file__).with_name("default_event_order.yml")
 
 
 class EventOrderGroup(BaseModel):
@@ -34,6 +39,20 @@ class EventOrderConfig(BaseModel):
         description="Named semantic event-order groups.",
     )
 
+    @classmethod
+    def load(cls, path: Path | None = None) -> Self:
+        """Load an event-order configuration.
+
+        If no path is provided, the built-in OpenICU default configuration
+        is loaded.
+        """
+        config_path = path or DEFAULT_EVENT_ORDER_CONFIG
+
+        with config_path.open("r") as f:
+            data = yaml.safe_load(f)
+
+        return cls(**data)
+
     @model_validator(mode="after")
     def validate_unique_concepts(self) -> "EventOrderConfig":
         """Ensure each concept is assigned to at most one group."""
@@ -64,3 +83,7 @@ class EventOrderConfig(BaseModel):
             for group in self.groups.values()
             for concept in group.concepts
         }
+
+    def order_for(self, concept: str) -> int:
+        """Return the configured order for a concept or the default order."""
+        return self.concept_orders().get(concept, self.default_order)

--- a/src/open_icu/steps/sharding/config/step.py
+++ b/src/open_icu/steps/sharding/config/step.py
@@ -1,5 +1,8 @@
 """Configuration models for the sharding step."""
 
+from pathlib import Path
+from typing import Self
+
 from pydantic import BaseModel, Field
 
 from open_icu.steps.base.config import BaseStepConfig
@@ -23,6 +26,8 @@ class CustomConfig(BaseModel):
             subjects.
         subjects_per_shard: Maximum number of subjects written to each shard
             file.
+        event_order_config: Optional path to a custom global event-order
+            configuration. If omitted, OpenICU uses its built-in default.
     """
 
     concept_step: str = Field(
@@ -49,9 +54,28 @@ class CustomConfig(BaseModel):
         gt=0,
         description="Number of subjects written per shard file.",
     )
+    event_order_config: Path | None = Field(
+        default=None,
+        description=(
+            "Optional path to a custom event-order configuration. "
+            "Relative paths are resolved relative to this sharding configuration file. "
+            "If omitted, OpenICU uses the built-in default event order."
+        ),
+    )
 
 
 class ShardingStepConfig(BaseStepConfig[CustomConfig]):
     """Complete configuration for the sharding step."""
 
-    pass
+    @classmethod
+    def load(cls, file_path: Path, **kwargs) -> Self:
+        """Load the sharding configuration and resolve relative file paths."""
+        config = super().load(file_path, **kwargs)
+
+        event_order_path = config.config.event_order_config
+        if event_order_path is not None and not event_order_path.is_absolute():
+            config.config.event_order_config = (
+                file_path.parent / event_order_path
+            ).resolve()
+
+        return config

--- a/src/open_icu/steps/sharding/step.py
+++ b/src/open_icu/steps/sharding/step.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import polars as pl
 
+from open_icu.config.event_order import EventOrderConfig
 from open_icu.logging import get_logger
 from open_icu.steps.base.step import ConfigurableBaseStep
 from open_icu.steps.sharding.config.sharding import ShardingConfig
@@ -53,6 +54,13 @@ class ShardingStep(ConfigurableBaseStep[ShardingStepConfig, ShardingConfig]):
 
         logger.info("Sharding %d concept file(s)", len(concept_files))
 
+        event_order = EventOrderConfig.load(self._config.config.event_order_config)
+        self._handle_unassigned_event_order(
+            event_order,
+            concept_files,
+            concept_dataset.data_path,
+        )
+
         subject_ids = self._subject_ids(concept_files)
         if not subject_ids:
             logger.warning("Skipping sharding step: no subjects found in selected concept files")
@@ -69,11 +77,81 @@ class ShardingStep(ConfigurableBaseStep[ShardingStepConfig, ShardingConfig]):
             )
 
             lf = self._scan_core_columns(concept_files).filter(pl.col("subject_id").is_in(shard_subjects))
-            lf = lf.sort(["subject_id", "time", "code"])
+            lf = self._apply_event_order(lf, event_order)
+            lf = lf.sort(["subject_id", "time", "_event_order", "code"]).drop("_event_order")
             lf.sink_parquet(output_file)
             written_files += 1
 
         logger.info("Finished sharding step: wrote %d shard file(s)", written_files)
+
+    @staticmethod
+    def _concept_names(
+        concept_files: list[Path],
+        concept_data_path: Path,
+    ) -> set[str]:
+        """Return concept names represented by the selected concept files."""
+        names: set[str] = set()
+
+        for file_path in concept_files:
+            relative_file_path = file_path.relative_to(concept_data_path)
+            relative_parts = relative_file_path.parts
+
+            if len(relative_parts) >= 3:
+                names.add(relative_parts[-3])
+
+        return names
+
+    @classmethod
+    def _handle_unassigned_event_order(
+        cls,
+        event_order: EventOrderConfig,
+        concept_files: list[Path],
+        concept_data_path: Path,
+    ) -> None:
+        """Handle selected concepts that use the default event order."""
+        configured_concepts = set(event_order.concept_orders())
+        selected_concepts = cls._concept_names(concept_files, concept_data_path)
+        unassigned = sorted(selected_concepts - configured_concepts)
+
+        if not unassigned or event_order.unassigned == "ignore":
+            return
+
+        message = (
+            f"{len(unassigned)} concept(s) use default event order "
+            f"{event_order.default_order}: {', '.join(unassigned)}"
+        )
+
+        if event_order.unassigned == "error":
+            raise ValueError(message)
+
+        logger.warning(message)
+
+    @staticmethod
+    def _apply_event_order(
+        lf: pl.LazyFrame,
+        event_order: EventOrderConfig,
+    ) -> pl.LazyFrame:
+        """Add a temporary semantic event-order column."""
+        concept = (
+            pl.col("code")
+            .str.split_exact("//", 1)
+            .struct.field("field_0")
+        )
+
+        order_expression = pl.lit(event_order.default_order)
+
+        for concept_name, order in reversed(
+            list(event_order.concept_orders().items())
+        ):
+            order_expression = (
+                pl.when(concept == concept_name)
+                .then(pl.lit(order))
+                .otherwise(order_expression)
+            )
+
+        return lf.with_columns(
+            order_expression.cast(pl.Int64).alias("_event_order")
+        )
 
     def _selected_concept_files(self, concept_data_path: Path) -> list[Path]:
         """Find concept Parquet files matching the configured dataset/concept filters."""

--- a/tests/steps/test_sharding_step.py
+++ b/tests/steps/test_sharding_step.py
@@ -166,3 +166,184 @@ config:
     shard = pl.read_parquet(output_file)
 
     assert shard["code"].unique().to_list() == ["heart_rate//bpm"]
+
+
+def test_sharding_orders_same_time_events_semantically(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    config_file = tmp_path / "sharding.yml"
+    config_file.write_text(
+        """\
+name: Sharding
+version: 1.0.0
+overwrite: true
+
+config:
+  concept_step: Concept
+  subjects_per_shard: 100
+"""
+    )
+
+    with OpenICUProject(project_path) as project:
+        concept_dataset = project.add_dataset("concept")
+
+        for concept, code in [
+            ("sofa", "sofa//points"),
+            ("gcs_total", "gcs_total//points"),
+            ("sofa_cns", "sofa_cns//points"),
+            ("gcs_eye", "gcs_eye//points"),
+        ]:
+            write_concept_file(
+                concept_dataset.data_path / concept / "1.0.0" / "testdb.parquet",
+                [1],
+                code,
+            )
+
+        ShardingStep.load(project, config_file).run()
+
+    output_file = project_path / "datasets" / "sharding" / "data" / "shard_00000.parquet"
+    shard = pl.read_parquet(output_file)
+
+    assert shard["code"].to_list() == [
+        "gcs_eye//points",
+        "gcs_total//points",
+        "sofa_cns//points",
+        "sofa//points",
+    ]
+
+
+def test_sharding_uses_custom_event_order_config(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    config_file = tmp_path / "sharding.yml"
+    event_order_file = tmp_path / "event_order.yml"
+
+    event_order_file.write_text(
+        """\
+default_order: 50
+unassigned: ignore
+
+groups:
+  first:
+    order: 10
+    concepts:
+      - sofa
+  second:
+    order: 20
+    concepts:
+      - heart_rate
+"""
+    )
+
+    config_file.write_text(
+        """\
+name: Sharding
+version: 1.0.0
+overwrite: true
+
+config:
+  concept_step: Concept
+  subjects_per_shard: 100
+  event_order_config: event_order.yml
+"""
+    )
+
+    with OpenICUProject(project_path) as project:
+        concept_dataset = project.add_dataset("concept")
+
+        write_concept_file(
+            concept_dataset.data_path / "heart_rate" / "1.0.0" / "testdb.parquet",
+            [1],
+            "heart_rate//bpm",
+        )
+        write_concept_file(
+            concept_dataset.data_path / "sofa" / "1.0.0" / "testdb.parquet",
+            [1],
+            "sofa//points",
+        )
+
+        ShardingStep.load(project, config_file).run()
+
+    output_file = project_path / "datasets" / "sharding" / "data" / "shard_00000.parquet"
+    shard = pl.read_parquet(output_file)
+
+    assert shard["code"].to_list() == [
+        "sofa//points",
+        "heart_rate//bpm",
+    ]
+
+
+def test_sharding_errors_on_unassigned_event_order(tmp_path: Path) -> None:
+    project_path = tmp_path / "project"
+    config_file = tmp_path / "sharding.yml"
+    event_order_file = tmp_path / "event_order.yml"
+
+    event_order_file.write_text(
+        """\
+default_order: 50
+unassigned: error
+
+groups:
+  configured:
+    order: 10
+    concepts:
+      - sofa
+"""
+    )
+
+    config_file.write_text(
+        """\
+name: Sharding
+version: 1.0.0
+overwrite: true
+
+config:
+  concept_step: Concept
+  event_order_config: event_order.yml
+"""
+    )
+
+    with OpenICUProject(project_path) as project:
+        concept_dataset = project.add_dataset("concept")
+
+        write_concept_file(
+            concept_dataset.data_path / "heart_rate" / "1.0.0" / "testdb.parquet",
+            [1],
+            "heart_rate//bpm",
+        )
+
+        try:
+            ShardingStep.load(project, config_file).run()
+        except ValueError as exc:
+            assert "heart_rate" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError for unassigned concept")
+
+
+def test_event_order_rejects_duplicate_concept_assignment(tmp_path: Path) -> None:
+    from pydantic import ValidationError
+
+    from open_icu.config.event_order import EventOrderConfig
+
+    event_order_file = tmp_path / "event_order.yml"
+    event_order_file.write_text(
+        """\
+default_order: 50
+unassigned: warn
+
+groups:
+  first:
+    order: 10
+    concepts:
+      - sofa
+  second:
+    order: 20
+    concepts:
+      - sofa
+"""
+    )
+
+    try:
+        EventOrderConfig.load(event_order_file)
+    except ValidationError as exc:
+        assert "multiple event-order groups" in str(exc)
+    else:
+        raise AssertionError("Expected ValidationError for duplicate concept assignment")


### PR DESCRIPTION
## Summary

Add configurable semantic ordering for events with identical timestamps. OpenICU now provides a built-in default event order, while the sharding step can optionally load a custom event-order configuration.

## Related Issue(s)

Closes https://github.com/aidh-ms/OpenICU/issues/724

## Changes

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] Test or tooling improvement

- Add a global event-order configuration model and built-in default ordering.
- Allow the sharding step to use an optional custom event-order configuration.
- Resolve relative event-order config paths relative to the sharding config file.
- Sort simultaneous events by semantic priority before using `code` as the deterministic tie-breaker.
- Support `ignore`, `warn`, and `error` handling for unassigned concepts.
- Validate that a concept cannot be assigned to multiple event-order groups.
- Keep the persisted sharding output schema unchanged.
- Add tests for semantic ordering, custom configs, unassigned concepts, and duplicate assignments.

## Checklist

- [x] Code is tested and builds correctly
- [ ] Docs updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)

## Notes for Reviewer

The event-order configuration is defined globally, although it is currently only consumed by the sharding step.

If no custom event-order configuration is provided, the built-in OpenICU default is used. The event-order value is only used as a temporary sort key and is not written to the output shards.

The sharding test suite passes with 8 tests.